### PR TITLE
Fix VersionEye Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Build Status](https://travis-ci.org/lightster/upcrypto.svg?branch=master)](https://travis-ci.org/lightster/upcrypto)
 [![Test Coverage](https://codeclimate.com/github/lightster/upcrypto/badges/coverage.svg)](https://codeclimate.com/github/lightster/upcrypto/coverage)
 [![Code Climate](https://codeclimate.com/github/lightster/upcrypto/badges/gpa.svg)](https://codeclimate.com/github/lightster/upcrypto)
-[![Dependency Status](https://www.versioneye.com/user/projects/532e6d03f599491449000238/badge.svg?style=flat)](https://www.versioneye.com/user/projects/532e6d03f599491449000238)
+[![Dependency Status](https://www.versioneye.com/user/projects/55bec48565376200200020bc/badge.svg?style=flat)](https://www.versioneye.com/user/projects/55bec48565376200200020bc)
 
 
 Streamline runtime upgrade of cryptography


### PR DESCRIPTION
The badge that was being displayed was for the lstr-silex project rather
than the upcrypto project