### PR TITLE
Remove HHVM from list of PHP versions to test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ php:
   - 5.5
   - 5.6
   - 7.0
-  - 7.1
 install:
   - composer install
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ php:
   - 5.5
   - 5.6
   - 7.0
-  - hhvm
+  - 7.1
 install:
   - composer install
 after_script:


### PR DESCRIPTION
The HHVM test environment will not boot up, and HHVM is not a priority to this project.