### PR TITLE
Add Defuse adapter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     "require-dev": {
         "phpunit/phpunit": "~4.5",
         "codeclimate/php-test-reporter": "dev-master",
-        "zendframework/zend-crypt": "~2.0"
+        "zendframework/zend-crypt": "~2.0",
+        "defuse/php-encryption": "^2.1.0"
     },
     "suggest": {
       "zendframework/zend-crypt:~2.0": "Include Zend\\Crypt 2.x if using the ZendCrypt adapter"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "7dc74b86c3e8126eedd465c948eced2e",
+    "content-hash": "24377839c8e02df19027c61ffdf4b949",
     "packages": [],
     "packages-dev": [
         {
@@ -91,6 +91,69 @@
             ],
             "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
             "time": "2014-12-30T15:22:37+00:00"
+        },
+        {
+            "name": "defuse/php-encryption",
+            "version": "v2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/defuse/php-encryption.git",
+                "reference": "5176f5abb38d3ea8a6e3ac6cd3bbb54d8185a689"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/defuse/php-encryption/zipball/5176f5abb38d3ea8a6e3ac6cd3bbb54d8185a689",
+                "reference": "5176f5abb38d3ea8a6e3ac6cd3bbb54d8185a689",
+                "shasum": ""
+            },
+            "require": {
+                "ext-openssl": "*",
+                "paragonie/random_compat": "~2.0",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "nikic/php-parser": "^2.0|^3.0",
+                "phpunit/phpunit": "^4|^5"
+            },
+            "bin": [
+                "bin/generate-defuse-key"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Defuse\\Crypto\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Hornby",
+                    "email": "taylor@defuse.ca",
+                    "homepage": "https://defuse.ca/"
+                },
+                {
+                    "name": "Scott Arciszewski",
+                    "email": "info@paragonie.com",
+                    "homepage": "https://paragonie.com"
+                }
+            ],
+            "description": "Secure PHP Encryption Library",
+            "keywords": [
+                "aes",
+                "authenticated encryption",
+                "cipher",
+                "crypto",
+                "cryptography",
+                "encrypt",
+                "encryption",
+                "openssl",
+                "security",
+                "symmetric key cryptography"
+            ],
+            "time": "2017-05-18T21:28:48+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -241,6 +304,54 @@
             ],
             "abandoned": "guzzlehttp/guzzle",
             "time": "2015-03-18T18:23:50+00:00"
+        },
+        {
+            "name": "paragonie/random_compat",
+            "version": "v2.0.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/random_compat.git",
+                "reference": "634bae8e911eefa89c1abfbf1b66da679ac8f54d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/634bae8e911eefa89c1abfbf1b66da679ac8f54d",
+                "reference": "634bae8e911eefa89c1abfbf1b66da679ac8f54d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*|5.*"
+            },
+            "suggest": {
+                "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/random.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com"
+                }
+            ],
+            "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
+            "keywords": [
+                "csprng",
+                "pseudorandom",
+                "random"
+            ],
+            "time": "2017-03-13T16:27:32+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",

--- a/src/Lstr/Upcrypto/CryptoAdapter/DefuseAdapter.php
+++ b/src/Lstr/Upcrypto/CryptoAdapter/DefuseAdapter.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Lstr\Upcrypto\CryptoAdapter;
+
+use Defuse\Crypto\Exception\WrongKeyOrModifiedCiphertextException;
+use Lstr\Upcrypto\Exception;
+use Defuse\Crypto\Crypto;
+use Defuse\Crypto\Key;
+
+class DefuseAdapter implements CryptoAdapterInterface
+{
+    /**
+     * @var string
+     */
+    private $crypto_key;
+
+    /**
+     * @var Key
+     */
+    private $raw_key;
+
+    /**
+     * @param array $params
+     *   - string $params['crypto_key'] - the encryption key
+     * @throws Exception
+     */
+    public function __construct(array $params)
+    {
+        if (!array_key_exists('crypto_key', $params)) {
+            throw new Exception(
+                __CLASS__ . " requires a 'crypto_key' parameter."
+            );
+        }
+
+        $this->crypto_key = $params['crypto_key'];
+    }
+
+    /**
+     * @param string $plain_text - the text to encrypt
+     * @return string - the encrypted text
+     */
+    public function encrypt($plain_text)
+    {
+        return Crypto::encrypt($plain_text, $this->getRawKey());
+    }
+
+    /**
+     * @param string $cipher_text - the text to decrypt
+     * @return string - the decrypted text
+     */
+    public function decrypt($cipher_text)
+    {
+        try {
+            return Crypto::decrypt($cipher_text, $this->getRawKey());
+        } catch (WrongKeyOrModifiedCiphertextException $ex) {
+            return false;
+        }
+    }
+
+    /**
+     * @return Key
+     */
+    private function getRawKey()
+    {
+        if ($this->raw_key) {
+            return $this->raw_key;
+        }
+
+        $this->raw_key = Key::loadFromAsciiSafeString($this->crypto_key);
+
+        return $this->raw_key;
+    }
+}

--- a/tests/src/Lstr/Upcrypto/CryptoAdapter/AbstractAdapterTest.php
+++ b/tests/src/Lstr/Upcrypto/CryptoAdapter/AbstractAdapterTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Lstr\Upcrypto\CryptoAdapter;
+
+use PHPUnit_Framework_TestCase;
+
+abstract class AbstractAdapterTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @covers ::__construct
+     * @covers ::encrypt
+     * @covers ::decrypt
+     * @covers ::<private>
+     */
+    public function testEncryptingAndDecryptingReturnsTheOriginalString()
+    {
+        $adapter = $this->getGoodCryptoAdapter();
+
+        $known_string = 'this string is known';
+        $this->assertEquals(
+            $known_string,
+            $adapter->decrypt($adapter->encrypt($known_string))
+        );
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::encrypt
+     * @covers ::decrypt
+     * @covers ::<private>
+     */
+    public function testUsingTheWrongDecryptionKeyThrowsAnException()
+    {
+        $encryption_adapter = $this->getGoodCryptoAdapter();
+        $decryption_adapter = $this->getBadCryptoAdapter();
+
+        $known_string = 'this string is known';
+        $this->assertFalse(
+            $decryption_adapter->decrypt(
+                $encryption_adapter->encrypt($known_string)
+            )
+        );
+    }
+
+    /**
+     * @return CryptoAdapterInterface
+     */
+    abstract protected function getGoodCryptoAdapter();
+
+    /**
+     * @return CryptoAdapterInterface
+     */
+    abstract protected function getBadCryptoAdapter();
+}

--- a/tests/src/Lstr/Upcrypto/CryptoAdapter/DefuseAdapterTest.php
+++ b/tests/src/Lstr/Upcrypto/CryptoAdapter/DefuseAdapterTest.php
@@ -2,58 +2,11 @@
 
 namespace Lstr\Upcrypto\CryptoAdapter;
 
-use PHPUnit_Framework_TestCase;
-
 /**
  * @coversDefaultClass \Lstr\Upcrypto\CryptoAdapter\DefuseAdapter
  */
-class DefuseAdapterTest extends PHPUnit_Framework_TestCase
+class DefuseAdapterTest extends AbstractAdapterTest
 {
-    /**
-     * @covers ::__construct
-     * @covers ::encrypt
-     * @covers ::decrypt
-     * @covers ::<private>
-     */
-    public function testEncryptingAndDecryptingReturnsTheOriginalString()
-    {
-        $adapter = new DefuseAdapter([
-            'crypto_key' => 'def000007abb9fab43861eb5a2579460cfcbec7774ecb84bf7ddd3379ebdcf52b6c'
-                . '22955049147eac6aa93ebfa6d2452650b222b1def408fe9c58ea527544a41602fe44f',
-        ]);
-
-        $known_string = 'this string is known';
-        $this->assertEquals(
-            $known_string,
-            $adapter->decrypt($adapter->encrypt($known_string))
-        );
-    }
-
-    /**
-     * @covers ::__construct
-     * @covers ::encrypt
-     * @covers ::decrypt
-     * @covers ::<private>
-     */
-    public function testUsingTheWrongDecryptionKeyThrowsAnException()
-    {
-        $encryption_adapter = new DefuseAdapter([
-            'crypto_key' => 'def000007abb9fab43861eb5a2579460cfcbec7774ecb84bf7ddd3379ebdcf52b6c2'
-                . '2955049147eac6aa93ebfa6d2452650b222b1def408fe9c58ea527544a41602fe44f',
-        ]);
-        $decryption_adapter = new DefuseAdapter([
-            'crypto_key' => 'def00000d988a0280b5580151c2f207934b6abcd5e59e2cab81c11214f6e2e84c1a8'
-                . '1627fb3e9634ae1c36d3958ca2491fb95a1337a897338030e77662b38a7cf7fc9dcd',
-        ]);
-
-        $known_string = 'this string is known';
-        $this->assertFalse(
-            $decryption_adapter->decrypt(
-                $encryption_adapter->encrypt($known_string)
-            )
-        );
-    }
-
     /**
      * @covers ::__construct
      * @expectedException \Lstr\Upcrypto\Exception
@@ -61,5 +14,27 @@ class DefuseAdapterTest extends PHPUnit_Framework_TestCase
     public function testFailingToProvideAKeyThrowsAnException()
     {
         new DefuseAdapter([]);
+    }
+
+    /**
+     * @return DefuseAdapter
+     */
+    protected function getGoodCryptoAdapter()
+    {
+        return new DefuseAdapter([
+            'crypto_key' => 'def000007abb9fab43861eb5a2579460cfcbec7774ecb84bf7ddd3379ebdcf52b6c2'
+                . '2955049147eac6aa93ebfa6d2452650b222b1def408fe9c58ea527544a41602fe44f',
+        ]);
+    }
+
+    /**
+     * @return DefuseAdapter
+     */
+    protected function getBadCryptoAdapter()
+    {
+        return new DefuseAdapter([
+            'crypto_key' => 'def00000d988a0280b5580151c2f207934b6abcd5e59e2cab81c11214f6e2e84c1a8'
+                . '1627fb3e9634ae1c36d3958ca2491fb95a1337a897338030e77662b38a7cf7fc9dcd',
+        ]);
     }
 }

--- a/tests/src/Lstr/Upcrypto/CryptoAdapter/DefuseAdapterTest.php
+++ b/tests/src/Lstr/Upcrypto/CryptoAdapter/DefuseAdapterTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Lstr\Upcrypto\CryptoAdapter;
+
+use PHPUnit_Framework_TestCase;
+
+/**
+ * @coversDefaultClass \Lstr\Upcrypto\CryptoAdapter\DefuseAdapter
+ */
+class DefuseAdapterTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @covers ::__construct
+     * @covers ::encrypt
+     * @covers ::decrypt
+     * @covers ::<private>
+     */
+    public function testEncryptingAndDecryptingReturnsTheOriginalString()
+    {
+        $adapter = new DefuseAdapter([
+            'crypto_key' => 'def000007abb9fab43861eb5a2579460cfcbec7774ecb84bf7ddd3379ebdcf52b6c'
+                . '22955049147eac6aa93ebfa6d2452650b222b1def408fe9c58ea527544a41602fe44f',
+        ]);
+
+        $known_string = 'this string is known';
+        $this->assertEquals(
+            $known_string,
+            $adapter->decrypt($adapter->encrypt($known_string))
+        );
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::encrypt
+     * @covers ::decrypt
+     * @covers ::<private>
+     */
+    public function testUsingTheWrongDecryptionKeyThrowsAnException()
+    {
+        $encryption_adapter = new DefuseAdapter([
+            'crypto_key' => 'def000007abb9fab43861eb5a2579460cfcbec7774ecb84bf7ddd3379ebdcf52b6c2'
+                . '2955049147eac6aa93ebfa6d2452650b222b1def408fe9c58ea527544a41602fe44f',
+        ]);
+        $decryption_adapter = new DefuseAdapter([
+            'crypto_key' => 'def00000d988a0280b5580151c2f207934b6abcd5e59e2cab81c11214f6e2e84c1a8'
+                . '1627fb3e9634ae1c36d3958ca2491fb95a1337a897338030e77662b38a7cf7fc9dcd',
+        ]);
+
+        $known_string = 'this string is known';
+        $this->assertFalse(
+            $decryption_adapter->decrypt(
+                $encryption_adapter->encrypt($known_string)
+            )
+        );
+    }
+
+    /**
+     * @covers ::__construct
+     * @expectedException \Lstr\Upcrypto\Exception
+     */
+    public function testFailingToProvideAKeyThrowsAnException()
+    {
+        new DefuseAdapter([]);
+    }
+}

--- a/tests/src/Lstr/Upcrypto/CryptoAdapter/ZendCryptAdapterTest.php
+++ b/tests/src/Lstr/Upcrypto/CryptoAdapter/ZendCryptAdapterTest.php
@@ -7,7 +7,7 @@ use PHPUnit_Framework_TestCase;
 /**
  * @coversDefaultClass \Lstr\Upcrypto\CryptoAdapter\ZendCryptAdapter
  */
-class ZendCryptAdapterTest extends PHPUnit_Framework_TestCase
+class ZendCryptAdapterTest extends AbstractAdapterTest
 {
     /**
      * @covers ::__construct
@@ -58,5 +58,25 @@ class ZendCryptAdapterTest extends PHPUnit_Framework_TestCase
     public function testFailingToProvideAKeyThrowsAnException()
     {
         new ZendCryptAdapter([]);
+    }
+
+    /**
+     * @return ZendCryptAdapter
+     */
+    protected function getGoodCryptoAdapter()
+    {
+        return new ZendCryptAdapter([
+            'crypto_key' => 'the correct password!',
+        ]);
+    }
+
+    /**
+     * @return ZendCryptAdapter
+     */
+    protected function getBadCryptoAdapter()
+    {
+        return new ZendCryptAdapter([
+            'crypto_key' => 'the incorrect password!',
+        ]);
     }
 }


### PR DESCRIPTION
mcrypt is deprecated in PHP 7.1, so an adapter that does not rely on
mcrypt needs to be made available. defuse/php-encryption is a
recommended encryption library

https://github.com/defuse/php-encryption

Issue #11