### PR TITLE
Remove duplicate adapter test methods

### DIFF
--- a/tests/src/Lstr/Upcrypto/CryptoAdapter/ZendCryptAdapterTest.php
+++ b/tests/src/Lstr/Upcrypto/CryptoAdapter/ZendCryptAdapterTest.php
@@ -21,48 +21,6 @@ class ZendCryptAdapterTest extends AbstractAdapterTest
 
     /**
      * @covers ::__construct
-     * @covers ::encrypt
-     * @covers ::decrypt
-     * @covers ::<private>
-     */
-    public function testEncryptingAndDecryptingReturnsTheOriginalString()
-    {
-        $adapter = new ZendCryptAdapter([
-            'crypto_key' => 'the correct password!',
-        ]);
-
-        $known_string = 'this string is known';
-        $this->assertEquals(
-            $known_string,
-            $adapter->decrypt($adapter->encrypt($known_string))
-        );
-    }
-
-    /**
-     * @covers ::__construct
-     * @covers ::encrypt
-     * @covers ::decrypt
-     * @covers ::<private>
-     */
-    public function testUsingTheWrongDecryptionKeyThrowsAnException()
-    {
-        $encryption_adapter = new ZendCryptAdapter([
-            'crypto_key' => 'the correct password!',
-        ]);
-        $decryption_adapter = new ZendCryptAdapter([
-            'crypto_key' => 'the incorrect password!',
-        ]);
-
-        $known_string = 'this string is known';
-        $this->assertFalse(
-            $decryption_adapter->decrypt(
-                $encryption_adapter->encrypt($known_string)
-            )
-        );
-    }
-
-    /**
-     * @covers ::__construct
      * @expectedException \Lstr\Upcrypto\Exception
      */
     public function testFailingToProvideAKeyThrowsAnException()


### PR DESCRIPTION
The parent class defines abstract versions of the test cases, so the
child class no longer needs to implement those test methods directly